### PR TITLE
Add memory and disk container metrics

### DIFF
--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -141,15 +141,14 @@ func (m *AppWatcher) processContainerMetric(metric *sonde_events.ContainerMetric
 	if int(index) < len(m.MetricsForInstance) {
 		instance := m.MetricsForInstance[index]
 
-		cpuPercentage := int(metric.GetCpuPercentage())
-		diskUtilizationPercentage := int(float64(metric.GetDiskBytes()) / float64(metric.GetDiskBytesQuota()) * 100)
-		memoryUtilizationPercentage := int(float64(metric.GetMemoryBytes()) / float64(metric.GetMemoryBytesQuota()) * 100)
+		diskUtilizationPercentage := float64(metric.GetDiskBytes()) / float64(metric.GetDiskBytesQuota()) * 100
+		memoryUtilizationPercentage := float64(metric.GetMemoryBytes()) / float64(metric.GetMemoryBytesQuota()) * 100
 
-		instance.Cpu.Set(float64(cpuPercentage))
+		instance.Cpu.Set(metric.GetCpuPercentage())
 		instance.DiskBytes.Set(float64(metric.GetDiskBytes()))
-		instance.DiskUtilization.Set(float64(diskUtilizationPercentage))
+		instance.DiskUtilization.Set(diskUtilizationPercentage)
 		instance.MemoryBytes.Set(float64(metric.GetMemoryBytes()))
-		instance.MemoryUtilization.Set(float64(memoryUtilizationPercentage))
+		instance.MemoryUtilization.Set(memoryUtilizationPercentage)
 	}
 }
 

--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -2,7 +2,6 @@ package events
 
 import (
 	"fmt"
-	"log"
 
 	sonde_events "github.com/cloudfoundry/sonde-go/events"
 	"github.com/prometheus/client_golang/prometheus"
@@ -137,11 +136,12 @@ func (m *AppWatcher) processContainerMetric(metric *sonde_events.ContainerMetric
 	if int(index) < len(m.MetricsForInstance) {
 		instance := m.MetricsForInstance[index]
 
-		diskUtilization := float64(metric.GetDiskBytes()) / float64(metric.GetDiskBytesQuota()) * 100
+		cpuPercentage := int(metric.GetCpuPercentage())
+		diskUtilizationPercentage := int(float64(metric.GetDiskBytes()) / float64(metric.GetDiskBytesQuota()) * 100)
 
-		instance.Cpu.Set(metric.GetCpuPercentage())
+		instance.Cpu.Set(float64(cpuPercentage))
 		instance.DiskBytes.Set(float64(metric.GetDiskBytes()))
-		instance.DiskUtilization.Set(float64(int(diskUtilization)))
+		instance.DiskUtilization.Set(float64(diskUtilizationPercentage))
 		instance.MemoryBytes.Set(float64(metric.GetMemoryBytes()))
 	}
 }

--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -24,50 +24,44 @@ type InstanceMetrics struct {
 }
 
 func NewInstanceMetrics(instanceIndex int, registerer prometheus.Registerer) InstanceMetrics {
+	constLabels := prometheus.Labels{
+		"instance": fmt.Sprintf("%d", instanceIndex),
+	}
+
 	im := InstanceMetrics{
 		Cpu: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "cpu",
 				Help: "CPU utilisation in percent (0-100)",
-				ConstLabels: prometheus.Labels{
-					"instance": fmt.Sprintf("%d", instanceIndex),
-				},
+				ConstLabels: constLabels,
 			},
 		),
 		DiskBytes: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "diskBytes",
 				Help: "Disk usage in bytes",
-				ConstLabels: prometheus.Labels{
-					"instance": fmt.Sprintf("%d", instanceIndex),
-				},
+				ConstLabels: constLabels,
 			},
 		),
 		DiskUtilization: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "diskUtilization",
 				Help: "Disk utilisation in percent (0-100)",
-				ConstLabels: prometheus.Labels{
-					"instance": fmt.Sprintf("%d", instanceIndex),
-				},
+				ConstLabels: constLabels,
 			},
 		),
 		MemoryBytes: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "memoryBytes",
 				Help: "Memory usage in bytes",
-				ConstLabels: prometheus.Labels{
-					"instance": fmt.Sprintf("%d", instanceIndex),
-				},
+				ConstLabels: constLabels,
 			},
 		),
 		MemoryUtilization: prometheus.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "memoryUtilization",
 				Help: "Memory utilisation in percent (0-100)",
-				ConstLabels: prometheus.Labels{
-					"instance": fmt.Sprintf("%d", instanceIndex),
-				},
+				ConstLabels: constLabels,
 			},
 		),
 	}

--- a/events/app_watcher_test.go
+++ b/events/app_watcher_test.go
@@ -74,19 +74,19 @@ var _ = Describe("AppWatcher", func() {
 		It("Registers metrics on startup", func() {
 			defer appWatcher.Close()
 
-			Eventually(registerer.MustRegisterCallCount).Should(Equal(1 * METRICS_PER_INSTANCE))
+			Eventually(registerer.MustRegisterCallCount).Should(Equal(METRICS_PER_INSTANCE))
 		})
 
 		It("Unregisters metrics on close", func() {
 			appWatcher.Close()
 
-			Eventually(registerer.UnregisterCallCount).Should(Equal(1 * METRICS_PER_INSTANCE))
+			Eventually(registerer.UnregisterCallCount).Should(Equal(METRICS_PER_INSTANCE))
 		})
 
 		It("Registers more metrics when new instances are created", func() {
 			defer appWatcher.Close()
 
-			Eventually(registerer.MustRegisterCallCount).Should(Equal(1 * METRICS_PER_INSTANCE))
+			Eventually(registerer.MustRegisterCallCount).Should(Equal(METRICS_PER_INSTANCE))
 
 			appWatcher.UpdateAppInstances(2)
 
@@ -102,7 +102,7 @@ var _ = Describe("AppWatcher", func() {
 
 			appWatcher.UpdateAppInstances(1)
 
-			Eventually(registerer.UnregisterCallCount).Should(Equal(1 * METRICS_PER_INSTANCE))
+			Eventually(registerer.UnregisterCallCount).Should(Equal(METRICS_PER_INSTANCE))
 		})
 
 		It("sets container metrics for an instance", func() {

--- a/events/app_watcher_test.go
+++ b/events/app_watcher_test.go
@@ -51,7 +51,7 @@ func (m *FakeRegistry) UnregisterCallCount() int {
 }
 
 var _ = Describe("AppWatcher", func() {
-	const METRICS_PER_INSTANCE = 3
+	const METRICS_PER_INSTANCE = 4
 
 	var (
 		appWatcher     *events.AppWatcher
@@ -160,6 +160,27 @@ var _ = Describe("AppWatcher", func() {
 			memoryBytesGauge := appWatcher.MetricsForInstance[instanceIndex].DiskBytes
 
 			Eventually(func() float64 { return testutil.ToFloat64(memoryBytesGauge) }).Should(Equal(float64(memoryBytes)))
+		})
+
+		It("sets a diskUtilization metric on an instance", func() {
+			var diskBytesQuota uint64 = 1024
+			var diskBytes uint64 = 512
+			var instanceIndex int32 = 0
+			containerMetric := sonde_events.ContainerMetric{
+				DiskBytes:      &diskBytes,
+				DiskBytesQuota: &diskBytesQuota,
+				InstanceIndex:  &instanceIndex,
+			}
+			messages := make(chan *sonde_events.Envelope, 1)
+			metricType := sonde_events.Envelope_ContainerMetric
+			messages <- &sonde_events.Envelope{ContainerMetric: &containerMetric, EventType: &metricType}
+			streamProvider.OpenStreamForReturns(messages, nil)
+
+			defer appWatcher.Close()
+
+			diskUtilizationGauge := appWatcher.MetricsForInstance[instanceIndex].DiskUtilization
+
+			Eventually(func() float64 { return testutil.ToFloat64(diskUtilizationGauge) }).Should(Equal(float64(50)))
 		})
 	})
 })

--- a/events/app_watcher_test.go
+++ b/events/app_watcher_test.go
@@ -54,9 +54,9 @@ var _ = Describe("AppWatcher", func() {
 	const METRICS_PER_INSTANCE = 5
 
 	var (
-		appWatcher     			 *events.AppWatcher
-		registerer     			 *FakeRegistry
-		streamProvider 			 *mocks.FakeAppStreamProvider
+		appWatcher     	         *events.AppWatcher
+		registerer     	         *FakeRegistry
+		streamProvider 	         *mocks.FakeAppStreamProvider
 		closeAppWatcherAfterTest bool
 	)
 
@@ -140,10 +140,10 @@ var _ = Describe("AppWatcher", func() {
 			Eventually(func() float64 { return testutil.ToFloat64(diskBytesGauge) }).Should(Equal(float64(diskBytes)))
 			Eventually(func() float64 { return testutil.ToFloat64(memoryBytesGauge) }).Should(Equal(float64(memoryBytes)))
 
-			// diskUtilization is a rounded percentage based on diskBytes/diskBytesQuota*100 (512/1024*100 = 50)
+			// diskUtilization is a percentage based on diskBytes/diskBytesQuota*100 (512/1024*100 = 50)
 			Eventually(func() float64 { return testutil.ToFloat64(diskUtilizationGauge) }).Should(Equal(float64(50)))
 
-			// diskUtilization is a rounded percentage based on memoryBytes/memoryBytesQuota*100 (1024/4096*100 = 25)
+			// diskUtilization is a percentage based on memoryBytes/memoryBytesQuota*100 (1024/4096*100 = 25)
 			Eventually(func() float64 { return testutil.ToFloat64(memoryUtilizationGauge) }).Should(Equal(float64(25)))
 		})
 	})


### PR DESCRIPTION
https://trello.com/c/yLIHCoT6/739-paas-prometheus-exporter-memory-and-disk-metrics

- Follows the same pattern as the already existing CPU metric
- Ensures all percentages are 0 decimal places to match existing behaviour of the paas-metric-exporter (CPU was not)
- removes unneeded `run` function calls as the appWatcher is `run` by default when it is created in our tests

One bit of behaviour not copied from the paas-metric-exporter is the ability to handle 0 value memory and disk quotas as things seem to work without it (https://github.com/alphagov/paas-metric-exporter/blob/master/processors/container_metric_processor.go). Not sure if this is something we should actually be doing though so looking for a second opinion on this.

Paired with the one and only @JonathanHallam 
