### PR TITLE
Change metric names from camel to snake case

### DIFF
--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -41,29 +41,29 @@ func NewInstanceMetrics(instanceIndex int, registerer prometheus.Registerer) Ins
 		),
 		DiskBytes: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "diskBytes",
+				Name: "disk_bytes",
 				Help: "Disk usage in bytes",
 				ConstLabels: constLabels,
 			},
 		),
 		DiskUtilization: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "diskUtilization",
-				Help: "Disk utilisation in percent (0-100)",
+				Name: "disk_utilization",
+				Help: "Disk space currently in use in percent (0-100)",
 				ConstLabels: constLabels,
 			},
 		),
 		MemoryBytes: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "memoryBytes",
+				Name: "memory_bytes",
 				Help: "Memory usage in bytes",
 				ConstLabels: constLabels,
 			},
 		),
 		MemoryUtilization: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "memoryUtilization",
-				Help: "Memory utilisation in percent (0-100)",
+				Name: "memory_utilization",
+				Help: "Memory currently in use in percent (0-100)",
 				ConstLabels: constLabels,
 			},
 		),


### PR DESCRIPTION
This is to mirror functionality of the PaaS metric exporter. Also slightly improved a couple of descriptions