### PR TITLE
Add org and space labels to metrics

### DIFF
--- a/exporter/exporter_cf_client.go
+++ b/exporter/exporter_cf_client.go
@@ -1,0 +1,38 @@
+package exporter
+
+import (
+	"net/url"
+
+	"github.com/cloudfoundry-community/go-cfclient"
+)
+
+type ExporterCFClient struct {
+	cf	*cfclient.Client
+}
+
+func NewCFClient(cf *cfclient.Client) CFClient {
+	return &ExporterCFClient {
+		cf: cf,
+	}
+}
+
+func (e *ExporterCFClient) ListAppsWithSpaceAndOrg() ([]cfclient.App, error) {
+	apps, err := e.cf.ListAppsByQuery(url.Values{})
+	if err != nil {
+		return apps, err
+	}
+	for idx, app := range apps {
+		space, err := app.Space()
+		if err != nil {
+			return apps, err
+		}
+		org, err := space.Org()
+		if err != nil {
+			return apps, err
+		}
+		space.OrgData.Entity = org
+		app.SpaceData.Entity = space
+		apps[idx] = app
+		}
+	return apps, nil
+}

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -24,7 +24,7 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("creates a new app", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STARTED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)
@@ -38,7 +38,7 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("does not create a new appWatcher if the app state is stopped", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STOPPED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)
@@ -51,10 +51,10 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("creates a new appWatcher if a stopped app is started", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturnsOnCall(0, []cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STOPPED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STARTED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)
@@ -68,7 +68,7 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("deletes an AppWatcher when an app is deleted", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturnsOnCall(0, []cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STARTED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{}, nil)
 
@@ -87,10 +87,10 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("deletes an AppWatcher when an app is stopped", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturnsOnCall(0, []cfclient.App{
-			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 1, Name: "foo", State: "STARTED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
+			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 1, Name: "foo", State: "STOPPED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)
@@ -108,10 +108,10 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("deletes and recreates an AppWatcher when an app is renamed", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturnsOnCall(0, []cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STARTED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "bar", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "bar", State: "STARTED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)
@@ -133,7 +133,6 @@ var _ = Describe("CheckForNewApps", func() {
 				Guid: "33333333-3333-3333-3333-333333333333",
 				Instances: 1,
 				Name: "foo",
-				SpaceURL: "/v2/spaces/123",
 				State: "STARTED",
 				SpaceData: cfclient.SpaceResource{Entity: cfclient.Space{Name: "spacename"}},
 			},
@@ -144,7 +143,6 @@ var _ = Describe("CheckForNewApps", func() {
 				Guid: "33333333-3333-3333-3333-333333333333",
 				Instances: 1,
 				Name: "foo",
-				SpaceURL: "/v2/spaces/123",
 				State: "STARTED",
 				SpaceData: cfclient.SpaceResource{Entity: cfclient.Space{Name: "spacenamenew"}},
 			},
@@ -169,7 +167,6 @@ var _ = Describe("CheckForNewApps", func() {
 				Guid: "33333333-3333-3333-3333-333333333333",
 				Instances: 1,
 				Name: "foo",
-				SpaceURL: "/v2/spaces/123",
 				State: "STARTED",
 				SpaceData: cfclient.SpaceResource{
 					Entity: cfclient.Space{
@@ -187,7 +184,6 @@ var _ = Describe("CheckForNewApps", func() {
 				Guid: "33333333-3333-3333-3333-333333333333",
 				Instances: 1,
 				Name: "foo",
-				SpaceURL: "/v2/spaces/123",
 				State: "STARTED",
 				SpaceData: cfclient.SpaceResource{
 					Entity: cfclient.Space{
@@ -215,10 +211,10 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("updates an AppWatcher when an app changes size", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturnsOnCall(0, []cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", State: "STARTED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 2, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 2, Name: "foo", State: "STARTED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -51,7 +51,7 @@ var _ = Describe("CheckForNewApps", func() {
 
 	It("creates a new appWatcher if a stopped app is started", func() {
 		fakeClient.ListAppsWithSpaceAndOrgReturnsOnCall(0, []cfclient.App{
-			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 0, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
+			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
 			{Guid: "33333333-3333-3333-3333-333333333333", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
@@ -90,7 +90,7 @@ var _ = Describe("CheckForNewApps", func() {
 			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STARTED"},
 		}, nil)
 		fakeClient.ListAppsWithSpaceAndOrgReturns([]cfclient.App{
-			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 0, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
+			{Guid: "11111111-11111-11111-1111-111-11-1-1-1", Instances: 1, Name: "foo", SpaceURL: "/v2/spaces/123", State: "STOPPED"},
 		}, nil)
 
 		e := exporter.New(fakeClient, fakeWatcherManager)

--- a/exporter/mocks/cfclient.go
+++ b/exporter/mocks/cfclient.go
@@ -2,7 +2,6 @@
 package mocks
 
 import (
-	url "net/url"
 	sync "sync"
 
 	exporter "github.com/alphagov/paas-prometheus-exporter/exporter"
@@ -10,16 +9,15 @@ import (
 )
 
 type FakeCFClient struct {
-	ListAppsByQueryStub        func(url.Values) ([]cfclient.App, error)
-	listAppsByQueryMutex       sync.RWMutex
-	listAppsByQueryArgsForCall []struct {
-		arg1 url.Values
+	ListAppsWithSpaceAndOrgStub        func() ([]cfclient.App, error)
+	listAppsWithSpaceAndOrgMutex       sync.RWMutex
+	listAppsWithSpaceAndOrgArgsForCall []struct {
 	}
-	listAppsByQueryReturns struct {
+	listAppsWithSpaceAndOrgReturns struct {
 		result1 []cfclient.App
 		result2 error
 	}
-	listAppsByQueryReturnsOnCall map[int]struct {
+	listAppsWithSpaceAndOrgReturnsOnCall map[int]struct {
 		result1 []cfclient.App
 		result2 error
 	}
@@ -27,64 +25,56 @@ type FakeCFClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCFClient) ListAppsByQuery(arg1 url.Values) ([]cfclient.App, error) {
-	fake.listAppsByQueryMutex.Lock()
-	ret, specificReturn := fake.listAppsByQueryReturnsOnCall[len(fake.listAppsByQueryArgsForCall)]
-	fake.listAppsByQueryArgsForCall = append(fake.listAppsByQueryArgsForCall, struct {
-		arg1 url.Values
-	}{arg1})
-	fake.recordInvocation("ListAppsByQuery", []interface{}{arg1})
-	fake.listAppsByQueryMutex.Unlock()
-	if fake.ListAppsByQueryStub != nil {
-		return fake.ListAppsByQueryStub(arg1)
+func (fake *FakeCFClient) ListAppsWithSpaceAndOrg() ([]cfclient.App, error) {
+	fake.listAppsWithSpaceAndOrgMutex.Lock()
+	ret, specificReturn := fake.listAppsWithSpaceAndOrgReturnsOnCall[len(fake.listAppsWithSpaceAndOrgArgsForCall)]
+	fake.listAppsWithSpaceAndOrgArgsForCall = append(fake.listAppsWithSpaceAndOrgArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListAppsWithSpaceAndOrg", []interface{}{})
+	fake.listAppsWithSpaceAndOrgMutex.Unlock()
+	if fake.ListAppsWithSpaceAndOrgStub != nil {
+		return fake.ListAppsWithSpaceAndOrgStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listAppsByQueryReturns
+	fakeReturns := fake.listAppsWithSpaceAndOrgReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeCFClient) ListAppsByQueryCallCount() int {
-	fake.listAppsByQueryMutex.RLock()
-	defer fake.listAppsByQueryMutex.RUnlock()
-	return len(fake.listAppsByQueryArgsForCall)
+func (fake *FakeCFClient) ListAppsWithSpaceAndOrgCallCount() int {
+	fake.listAppsWithSpaceAndOrgMutex.RLock()
+	defer fake.listAppsWithSpaceAndOrgMutex.RUnlock()
+	return len(fake.listAppsWithSpaceAndOrgArgsForCall)
 }
 
-func (fake *FakeCFClient) ListAppsByQueryCalls(stub func(url.Values) ([]cfclient.App, error)) {
-	fake.listAppsByQueryMutex.Lock()
-	defer fake.listAppsByQueryMutex.Unlock()
-	fake.ListAppsByQueryStub = stub
+func (fake *FakeCFClient) ListAppsWithSpaceAndOrgCalls(stub func() ([]cfclient.App, error)) {
+	fake.listAppsWithSpaceAndOrgMutex.Lock()
+	defer fake.listAppsWithSpaceAndOrgMutex.Unlock()
+	fake.ListAppsWithSpaceAndOrgStub = stub
 }
 
-func (fake *FakeCFClient) ListAppsByQueryArgsForCall(i int) url.Values {
-	fake.listAppsByQueryMutex.RLock()
-	defer fake.listAppsByQueryMutex.RUnlock()
-	argsForCall := fake.listAppsByQueryArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCFClient) ListAppsByQueryReturns(result1 []cfclient.App, result2 error) {
-	fake.listAppsByQueryMutex.Lock()
-	defer fake.listAppsByQueryMutex.Unlock()
-	fake.ListAppsByQueryStub = nil
-	fake.listAppsByQueryReturns = struct {
+func (fake *FakeCFClient) ListAppsWithSpaceAndOrgReturns(result1 []cfclient.App, result2 error) {
+	fake.listAppsWithSpaceAndOrgMutex.Lock()
+	defer fake.listAppsWithSpaceAndOrgMutex.Unlock()
+	fake.ListAppsWithSpaceAndOrgStub = nil
+	fake.listAppsWithSpaceAndOrgReturns = struct {
 		result1 []cfclient.App
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeCFClient) ListAppsByQueryReturnsOnCall(i int, result1 []cfclient.App, result2 error) {
-	fake.listAppsByQueryMutex.Lock()
-	defer fake.listAppsByQueryMutex.Unlock()
-	fake.ListAppsByQueryStub = nil
-	if fake.listAppsByQueryReturnsOnCall == nil {
-		fake.listAppsByQueryReturnsOnCall = make(map[int]struct {
+func (fake *FakeCFClient) ListAppsWithSpaceAndOrgReturnsOnCall(i int, result1 []cfclient.App, result2 error) {
+	fake.listAppsWithSpaceAndOrgMutex.Lock()
+	defer fake.listAppsWithSpaceAndOrgMutex.Unlock()
+	fake.ListAppsWithSpaceAndOrgStub = nil
+	if fake.listAppsWithSpaceAndOrgReturnsOnCall == nil {
+		fake.listAppsWithSpaceAndOrgReturnsOnCall = make(map[int]struct {
 			result1 []cfclient.App
 			result2 error
 		})
 	}
-	fake.listAppsByQueryReturnsOnCall[i] = struct {
+	fake.listAppsWithSpaceAndOrgReturnsOnCall[i] = struct {
 		result1 []cfclient.App
 		result2 error
 	}{result1, result2}
@@ -93,8 +83,8 @@ func (fake *FakeCFClient) ListAppsByQueryReturnsOnCall(i int, result1 []cfclient
 func (fake *FakeCFClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.listAppsByQueryMutex.RLock()
-	defer fake.listAppsByQueryMutex.RUnlock()
+	fake.listAppsWithSpaceAndOrgMutex.RLock()
+	defer fake.listAppsWithSpaceAndOrgMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/main.go
+++ b/main.go
@@ -38,7 +38,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	e := exporter.New(cf, exporter.NewWatcherManager(config))
+	exporter_cf := exporter.NewCFClient(cf)
+
+	e := exporter.New(exporter_cf, exporter.NewWatcherManager(config))
 	go e.Start(time.Duration(*updateFrequency) * time.Second)
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *prometheusBindPort), nil))


### PR DESCRIPTION
https://trello.com/c/EpJdzW0r/742-paas-prometheus-exporter-org-and-space-labels

- Introduces an `ExporterCFClient` so we always get and attach
space and org data to an `cfclient.App`
- Add space and org labels to metrics
- Recreates appWatchers if the space name or org name for an app
changes using `CFNames` struct for comparison between new and old
data from the CF API

Also does a few small refactors as the final commits (see commit messages).

Note, we considered adding a `guid` type to make our code easier to read but given the cfclient.App returns it's guid as a string we have to convert it from type string to type guid everytime we want to access it and pass it around our functions which ended up looking a bit messy so decided not to do this for the moment. A new guid type would also need to be shared with `app_watcher.go`.