### PR TITLE
Add crashes counter

### DIFF
--- a/events/app_watcher_test.go
+++ b/events/app_watcher_test.go
@@ -3,6 +3,7 @@ package events_test
 import (
 	"errors"
 	"sync"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -51,7 +52,7 @@ func (m *FakeRegistry) UnregisterCallCount() int {
 }
 
 var _ = Describe("AppWatcher", func() {
-	const METRICS_PER_INSTANCE = 5
+	const METRICS_PER_INSTANCE = 6
 
 	var (
 		appWatcher     	         *events.AppWatcher
@@ -70,6 +71,7 @@ var _ = Describe("AppWatcher", func() {
 		appWatcher = events.NewAppWatcher(apps[0], registerer, streamProvider)
 		closeAppWatcherAfterTest = true
 	})
+
 	AfterEach(func() {
 		if closeAppWatcherAfterTest {
 			appWatcher.Close()
@@ -146,5 +148,126 @@ var _ = Describe("AppWatcher", func() {
 			// diskUtilization is a percentage based on memoryBytes/memoryBytesQuota*100 (1024/4096*100 = 25)
 			Eventually(func() float64 { return testutil.ToFloat64(memoryUtilizationGauge) }).Should(Equal(float64(25)))
 		})
+
+		It("Increments the 'crashes' metric", func() {
+			var instanceIndex int32 = 0
+			envelopeLogMessageEventType := sonde_events.Envelope_LogMessage
+			logMessageOutMessageType := sonde_events.LogMessage_OUT
+			crashEnvelope := sonde_events.Envelope{
+				Origin:    str("cloud_controller"),
+				EventType: &envelopeLogMessageEventType,
+				LogMessage: &sonde_events.LogMessage{
+					Message:        []byte(fmt.Sprintf(
+						"App instance exited with guid 4630f6ba-8ddc-41f1-afea-1905332d6660 payload: " +
+						"{\"instance\"=>\"bc932892-f191-4fe2-60c3-7090\", \"index\"=>%d, \"reason\"=>\"CRASHED\"," +
+						" \"exit_description\"=>\"APP/PROC/WEB: Exited with status 137\", \"crash_count\"=>1," +
+						" \"crash_timestamp\"=>1512569260335558205, \"version\"=>\"d24b0422-0c88-4692-bf52-505091890e7d\"}",
+						instanceIndex),
+					),
+					MessageType:    &logMessageOutMessageType,
+					AppId:          str("4630f6ba-8ddc-41f1-afea-1905332d6660"),
+					SourceType:     str("API"),
+					SourceInstance: str("1"),
+				},
+			}
+
+			messages := make(chan *sonde_events.Envelope, 1)
+			streamProvider.OpenStreamForReturns(messages, nil)
+			crashCounter := &appWatcher.MetricsForInstance[instanceIndex].Crashes
+
+			messages <- &crashEnvelope
+			Eventually(func() float64 { return testutil.ToFloat64(*crashCounter) }).Should(Equal(float64(1)))
+
+			// Send another message to be extra confident that the behaviour is incremental
+			messages <- &crashEnvelope
+			Eventually(func() float64 { return testutil.ToFloat64(*crashCounter) }).Should(Equal(float64(2)))
+		})
+
+		It("Does not increment the 'crashes' metric if not source type API, does not have App instance exited with guid, not LogMessage_OUT or not reason CRASHED", func() {
+			var instanceIndex int32 = 0
+			envelopeLogMessageEventType := sonde_events.Envelope_LogMessage
+			logMessageOutMessageType := sonde_events.LogMessage_OUT
+			logMessageErrMessageType := sonde_events.LogMessage_ERR
+
+			appNonCrashEnvelopes := []sonde_events.Envelope{
+				// source type not API
+				sonde_events.Envelope{
+					Origin:    str("gorouter"),
+					EventType: &envelopeLogMessageEventType,
+					LogMessage: &sonde_events.LogMessage{
+						Message:        []byte("dora.dcarley.dev.cloudpipelineapps.digital - [2017-12-06T14:05:45.897+0000] \"GET / HTTP/1.1\" 200 0 13 \"-\" \"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36\" \"127.0.0.1:48966\" \"10.0.34.4:61223\" x_forwarded_for:\"213.86.153.212, 127.0.0.1\" x_forwarded_proto:\"https\" vcap_request_id:\"cd809903-c35d-4c98-6f62-1f22862cc82c\" response_time:0.018321645 app_id:\"4630f6ba-8ddc-41f1-afea-1905332d6660\" app_index:\"0\"\n"),
+						MessageType:    &logMessageOutMessageType,
+						AppId:          str("4630f6ba-8ddc-41f1-afea-1905332d6660"),
+						SourceType:     str("RTR"),
+						SourceInstance: str("1"),
+					},
+				},
+				// log message type error
+				sonde_events.Envelope{
+					Origin:    str("rep"),
+					EventType: &envelopeLogMessageEventType,
+					LogMessage: &sonde_events.LogMessage{
+						Message:        []byte("[2017-12-06 14:06:41] INFO  WEBrick 1.3.1"),
+						MessageType:    &logMessageErrMessageType,
+						AppId:          str("4630f6ba-8ddc-41f1-afea-1905332d6660"),
+						SourceType:     str("APP/PROC/WEB"),
+						SourceInstance: str("0"),
+					},
+				},
+				// Does not start with App instance exited with guid
+				sonde_events.Envelope{
+					Origin:    str("cloud_controller"),
+					EventType: &envelopeLogMessageEventType,
+					LogMessage: &sonde_events.LogMessage{
+						Message:        []byte("Updated app with guid 4630f6ba-8ddc-41f1-afea-1905332d6660 ({\"state\"=>\"STOPPED\"})"),
+						MessageType:    &logMessageOutMessageType,
+						AppId:          str("4630f6ba-8ddc-41f1-afea-1905332d6660"),
+						SourceType:     str("API"),
+						SourceInstance: str("1"),
+					},
+				},
+				// no payload
+				sonde_events.Envelope{
+					Origin:    str("cloud_controller"),
+					EventType: &envelopeLogMessageEventType,
+					LogMessage: &sonde_events.LogMessage{
+						Message:        []byte("Process has crashed with type: \"web\""),
+						MessageType:    &logMessageOutMessageType,
+						AppId:          str("4630f6ba-8ddc-41f1-afea-1905332d6660"),
+						SourceType:     str("API"),
+						SourceInstance: str("1"),
+					},
+				},
+				// payload does not have CRASHED reason
+				sonde_events.Envelope{
+					Origin:    str("cloud_controller"),
+					EventType: &envelopeLogMessageEventType,
+					LogMessage: &sonde_events.LogMessage{
+						Message:        []byte("Test without CRASHED payload: \"reason\"=>\"NOT_CRASHED\""),
+						MessageType:    &logMessageOutMessageType,
+						AppId:          str("4630f6ba-8ddc-41f1-afea-1905332d6660"),
+						SourceType:     str("API"),
+						SourceInstance: str("1"),
+					},
+				},
+			}
+
+			messages := make(chan *sonde_events.Envelope, len(appNonCrashEnvelopes))
+			streamProvider.OpenStreamForReturns(messages, nil)
+			crashCounter := &appWatcher.MetricsForInstance[instanceIndex].Crashes
+
+			for _, envelope := range appNonCrashEnvelopes {
+				messages <- &envelope
+			}
+
+			Consistently(func() float64 { return testutil.ToFloat64(*crashCounter) }).Should(Equal(float64(0)))	
+		})
+
+		// TODO: should we test the error paths?
+		// how do we test them? As they are no handled but simply bubble up and then ignored
 	})
 })
+
+func str(s string) *string {
+	return &s
+}


### PR DESCRIPTION
https://trello.com/c/0FRam3Gr/740-paas-prometheus-exporter-crashes-counter

Follows very similar logic to our other instance metrics. The
only difference is the source of data is from log message events
rather than container metric events. To support this we have
copied and adapted most of the `log_message_processor` and its
tests from the paas-metric-exporter (see
https://github.com/alphagov/paas-metric-exporter/blob/master/processors/log_message_processor.go).