### PR TITLE
Add build_info metric for PaaS Prometheus Exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/mo
 |Update frequency|update-frequency|UPDATE_FREQUENCY|The time in seconds, that takes between each apps update call|
 |Prometheus Bind Port|prometheus-bind-port|PORT|The port that the prometheus server binds to. Default is 8080|
 
+## Development
+
+With each update of the PaaS Prometheus Exporter you should update the version number located in `main.go` file at the top of the `var` block.
+
 ## Testing
 
 To run the test suite, first make sure you have ginkgo and gomega installed:

--- a/main.go
+++ b/main.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/alphagov/paas-prometheus-exporter/exporter"
 	"github.com/cloudfoundry-community/go-cfclient"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
+	version            = "0.0.1"
 	apiEndpoint        = kingpin.Flag("api-endpoint", "API endpoint").Default("https://api.10.244.0.34.xip.io").OverrideDefaultFromEnvar("API_ENDPOINT").String()
 	username           = kingpin.Flag("username", "UAA username.").Default("").OverrideDefaultFromEnvar("USERNAME").String()
 	password           = kingpin.Flag("password", "UAA password.").Default("").OverrideDefaultFromEnvar("PASSWORD").String()
@@ -37,6 +39,18 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	build_info := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "paas_exporter_build_info",
+			Help: "PaaS Prometheus exporter build info.",
+			ConstLabels: prometheus.Labels{
+				"version": version,
+			},
+		},
+	)
+	build_info.Set(1)
+	prometheus.DefaultRegisterer.MustRegister(build_info)
 
 	exporter_cf := exporter.NewCFClient(cf)
 


### PR DESCRIPTION
## What

Added `build_info` gauge metric to show the PaaS prometheus exporter version deployed, will be useful to determine what version a user is running in case there are problems with a particular release.

Also updated the `README` with information on where to update the version and should follow [SemVer](https://semver.org/#semantic-versioning-specification-semver) rules.

https://trello.com/c/n4E4klcs/686-paas-prometheus-exporter-paasexporterbuildinfo-metric-to-show-which-version-is-being-run