### PR TITLE
Add requests and response time metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,93 +2,72 @@
 
 
 [[projects]]
-  digest = "1:5d869c1def0f6b09b69b3aa3e4d3e66237e0bdade5803985e2d8985a2f690e95"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse",
+    "parse"
   ]
-  pruneopts = ""
   revision = "b867cc6ab45cece8143cfcc6fc9c77cf3f2c23c0"
 
 [[projects]]
-  digest = "1:9e223a7649834e3f7f87a1b943e9fbd909db7d4e59020a178c512f54261d065c"
   name = "github.com/alecthomas/units"
   packages = ["."]
-  pruneopts = ""
   revision = "6b4e7dc5e3143b85ea77909c72caf89416fc2915"
 
 [[projects]]
   branch = "master"
-  digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
-  pruneopts = ""
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
-  digest = "1:5706e838254152e4fe3bdaff4b62431407a294e280731dd3575b04825b9a6c92"
   name = "github.com/cloudfoundry-community/go-cfclient"
   packages = ["."]
-  pruneopts = ""
   revision = "4baef162cb52acb882b0cb991756604c7fa4c580"
 
 [[projects]]
-  digest = "1:670c662d5ef5ea5bced8f67f31ae1b615af78fe32391efc6d48d5fde015b6f56"
   name = "github.com/cloudfoundry/noaa"
   packages = [
     ".",
     "consumer",
     "consumer/internal",
-    "errors",
+    "errors"
   ]
-  pruneopts = ""
   revision = "a658db22c62ed0fa527c789997572a346b3faa6b"
 
 [[projects]]
-  digest = "1:ff0f39ab01a067fe235b18265fc7d1522ada75549ed86e559614b8f0649efd75"
   name = "github.com/cloudfoundry/sonde-go"
   packages = ["events"]
-  pruneopts = ""
   revision = "78019103037ae46207993c8816e970d85bf1a9e4"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
   name = "github.com/gogo/protobuf"
   packages = [
     "gogoproto",
     "proto",
-    "protoc-gen-gogo/descriptor",
+    "protoc-gen-gogo/descriptor"
   ]
-  pruneopts = ""
   revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
-  pruneopts = ""
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:8e1784f6f2589838806cb64024af2f1b72516f3d6cbe6c286f5e5895beb9e221"
   name = "github.com/gorilla/websocket"
   packages = ["."]
-  pruneopts = ""
   revision = "9007e29a7c93fc3dcebbdbf742ce0efaf19e6510"
 
 [[projects]]
-  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
-  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:579a46d045ad9cadda136198e7c50da86cfcf4e74e28f8ac4385963b80a12a33"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -105,13 +84,11 @@
     "internal/writer",
     "reporters",
     "reporters/stenographer",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "07d85e6b10c4289c7d612f9b13f45ba36f66d55b"
 
 [[projects]]
-  digest = "1:3ecd0a37c4a90c12a97e31c398cdbc173824351aa891898ee178120bfe71c478"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -125,84 +102,70 @@
     "matchers/support/goraph/edge",
     "matchers/support/goraph/node",
     "matchers/support/goraph/util",
-    "types",
+    "types"
   ]
-  pruneopts = ""
   revision = "7615b9433f86a8bdf29709bf288bc4fd0636a369"
   version = "v1.4.2"
 
 [[projects]]
-  digest = "1:8b2082f564fe20dbb43a621ee0d57ae2777656ab14111d100d3d92d1b5b958b9"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
     "prometheus/internal",
     "prometheus/promhttp",
-    "prometheus/testutil",
+    "prometheus/testutil"
   ]
-  pruneopts = ""
   revision = "abad2d1bd44235a26707c172eab6bca5bf2dbad3"
   version = "v0.9.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:60aca47f4eeeb972f1b9da7e7db51dee15ff6c59f7b401c1588b8e6771ba15ef"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
-  pruneopts = ""
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
-  digest = "1:545c0adfcd1c5a3d155cfada997c426d3e4b358ba26cf7a1ace99fd9230e63de"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model",
+    "model"
   ]
-  pruneopts = ""
   revision = "e4aa40a9169a88835b849a6efb71e05dc04b88f0"
 
 [[projects]]
   branch = "master"
-  digest = "1:9a89d28f6d0bacb0b31d66f85a51f2b4f52592807c3aed15a889e816143412ae"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs",
+    "xfs"
   ]
-  pruneopts = ""
   revision = "54d17b57dd7d4a3aa092476596b3f8a933bde349"
 
 [[projects]]
   branch = "master"
-  digest = "1:fbdbb6cf8db3278412c9425ad78b26bb8eb788181f26a3ffb3e4f216b314f86a"
   name = "golang.org/x/net"
   packages = [
     "context",
     "html",
     "html/atom",
-    "html/charset",
+    "html/charset"
   ]
-  pruneopts = ""
   revision = "26e67e76b6c3f6ce91f7c52def5af501b4e0f3a2"
 
 [[projects]]
-  digest = "1:a117d3544736d3de68a8f1716cc11a501d5557fc646fb12d6093252a06728d8b"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
     "clientcredentials",
-    "internal",
+    "internal"
   ]
-  pruneopts = ""
   revision = "314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
   name = "golang.org/x/text"
   packages = [
     "encoding",
@@ -221,14 +184,12 @@
     "language",
     "runes",
     "transform",
-    "unicode/cldr",
+    "unicode/cldr"
   ]
-  pruneopts = ""
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -237,41 +198,26 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch",
+    "urlfetch"
   ]
-  pruneopts = ""
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:5b9a646cda900787e9863ea86cf4b92dbb2f9d75d3b939d78b7d3b25bd37b37a"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "a7274600e78d26876a32d8b293cbb0cd324f61a2"
   version = "v2.0.8"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/cloudfoundry-community/go-cfclient",
-    "github.com/cloudfoundry/noaa/consumer",
-    "github.com/cloudfoundry/sonde-go/events",
-    "github.com/onsi/ginkgo",
-    "github.com/onsi/gomega",
-    "github.com/prometheus/client_golang/prometheus",
-    "github.com/prometheus/client_golang/prometheus/promhttp",
-    "github.com/prometheus/client_golang/prometheus/testutil",
-    "gopkg.in/alecthomas/kingpin.v2",
-  ]
+  inputs-digest = "b654489edc263824b9242afc747b5fb467cd4a71fd67b545d3a8f4b6b9b8db17"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -255,7 +255,7 @@ func (m *AppWatcher) processLogMessage(logMessage *sonde_events.LogMessage) erro
 }
 
 func (m *AppWatcher) processHttpStartStopMetric(httpStartStop *sonde_events.HttpStartStop) {
-	responseDuration := float64(time.Duration(httpStartStop.GetStopTimestamp() - httpStartStop.GetStartTimestamp())) / float64(time.Second)
+	responseDuration := time.Duration(httpStartStop.GetStopTimestamp() - httpStartStop.GetStartTimestamp()).Seconds()
 	index := int(httpStartStop.GetInstanceIndex())
 	if index < len(m.MetricsForInstance) {
 		statusRange := fmt.Sprintf("%dxx", *httpStartStop.StatusCode / 100)

--- a/events/events_suite_test.go
+++ b/events/events_suite_test.go
@@ -2,12 +2,14 @@ package events_test
 
 import (
 	"testing"
+	"log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestEvents(t *testing.T) {
+	log.SetOutput(GinkgoWriter)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Events Suite")
 }

--- a/exporter/exporter_suite_test.go
+++ b/exporter/exporter_suite_test.go
@@ -2,12 +2,14 @@ package exporter_test
 
 import (
 	"testing"
+	"log"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestExporter(t *testing.T) {
+	log.SetOutput(GinkgoWriter)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Exporter Suite")
 }

--- a/main.go
+++ b/main.go
@@ -28,11 +28,11 @@ func main() {
 	kingpin.Parse()
 
 	config := &cfclient.Config{
-		ApiAddress:        *apiEndpoint,
-		Username:          *username,
-		Password:          *password,
-		ClientID:          *clientID,
-		ClientSecret:      *clientSecret,
+		ApiAddress:   *apiEndpoint,
+		Username:     *username,
+		Password:     *password,
+		ClientID:     *clientID,
+		ClientSecret: *clientSecret,
 	}
 
 	cf, err := cfclient.NewClient(config)


### PR DESCRIPTION
https://trello.com/c/wy3K0DB7/741-paas-prometheus-exporter-requests-and-response-times

This adds in requests and response time metrics broken down into status ranges 2, 3, 4 and 5xx. They are all initialised with a zero value.  The paas-metric-exporter had functionality for 1xx and other response codes. We have elected not to do this because we never expect to have these codes.

In our tests we moved the creation of the message chan into the before each to avoid race conditions.

We have not tested response times explicitly, this is because it was not possible to get private data about buckets and their values from the response_time histogram. We looked into using the registerer but were not able to do a more integration style test using this method because it's being mocked. We decided the time needed to have good tests for this was not worth the benefit. Our changes have been manually tested and we get all the information we were expecting.

#### Question for reviewer
The `withLabelValues` method that we are using to get information out of the request and response histograms in `processHttpStartStopMetric` function panics rather than returning an error. This means there is a risk that our programme will panic, instead we could bubble an error up, thoughts?

![image](https://user-images.githubusercontent.com/24547207/49286102-4cc1ba80-f491-11e8-8027-635693796c1c.png)
