### PR TITLE
Bubblin

### DIFF
--- a/events/app_watcher_test.go
+++ b/events/app_watcher_test.go
@@ -74,7 +74,7 @@ var _ = Describe("AppWatcher", func() {
 		sondeEventChan = make(chan *sonde_events.Envelope, 10)
 		streamProvider.OpenStreamForReturns(sondeEventChan, nil)
 
-		appWatcher = events.NewAppWatcher(apps[0], registerer, streamProvider)
+		appWatcher, _ = events.NewAppWatcher(apps[0], registerer, streamProvider)
 		closeAppWatcherAfterTest = true
 	})
 

--- a/events/stream_provider.go
+++ b/events/stream_provider.go
@@ -1,8 +1,6 @@
 package events
 
 import (
-	"crypto/tls"
-
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/cloudfoundry/noaa/consumer"
 	sonde_events "github.com/cloudfoundry/sonde-go/events"
@@ -27,18 +25,18 @@ type DopplerAppStreamProvider struct {
 func (m *DopplerAppStreamProvider) OpenStreamFor(appGuid string) (<-chan *sonde_events.Envelope, <-chan error) {
 	err := m.authenticate()
 	if err != nil {
-		errs := make(chan error,1)
+		errs := make(chan error, 1)
 		errs <- err
 		return nil, errs
 	}
-	tlsConfig := tls.Config{InsecureSkipVerify: false} // TODO: is this needed?
-	conn := consumer.New(m.cfClient.Endpoint.DopplerEndpoint, &tlsConfig, nil)
+
+	conn := consumer.New(m.cfClient.Endpoint.DopplerEndpoint, nil, nil)
 	m.conn = conn
 	conn.RefreshTokenFrom(m)
 
 	authToken, err := m.cfClient.GetToken()
 	if err != nil {
-		errs := make(chan error,1)
+		errs := make(chan error, 1)
 		errs <- err
 		return nil, errs
 	}

--- a/exporter/exporter_cf_client.go
+++ b/exporter/exporter_cf_client.go
@@ -33,6 +33,6 @@ func (e *ExporterCFClient) ListAppsWithSpaceAndOrg() ([]cfclient.App, error) {
 		space.OrgData.Entity = org
 		app.SpaceData.Entity = space
 		apps[idx] = app
-		}
+	}
 	return apps, nil
 }

--- a/exporter/mocks/watcher_manager.go
+++ b/exporter/mocks/watcher_manager.go
@@ -10,11 +10,17 @@ import (
 )
 
 type FakeWatcherManager struct {
-	AddWatcherStub        func(cfclient.App, prometheus.Registerer)
+	AddWatcherStub        func(cfclient.App, prometheus.Registerer) error
 	addWatcherMutex       sync.RWMutex
 	addWatcherArgsForCall []struct {
 		arg1 cfclient.App
 		arg2 prometheus.Registerer
+	}
+	addWatcherReturns struct {
+		result1 error
+	}
+	addWatcherReturnsOnCall map[int]struct {
+		result1 error
 	}
 	DeleteWatcherStub        func(string)
 	deleteWatcherMutex       sync.RWMutex
@@ -30,8 +36,9 @@ type FakeWatcherManager struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeWatcherManager) AddWatcher(arg1 cfclient.App, arg2 prometheus.Registerer) {
+func (fake *FakeWatcherManager) AddWatcher(arg1 cfclient.App, arg2 prometheus.Registerer) error {
 	fake.addWatcherMutex.Lock()
+	ret, specificReturn := fake.addWatcherReturnsOnCall[len(fake.addWatcherArgsForCall)]
 	fake.addWatcherArgsForCall = append(fake.addWatcherArgsForCall, struct {
 		arg1 cfclient.App
 		arg2 prometheus.Registerer
@@ -39,8 +46,13 @@ func (fake *FakeWatcherManager) AddWatcher(arg1 cfclient.App, arg2 prometheus.Re
 	fake.recordInvocation("AddWatcher", []interface{}{arg1, arg2})
 	fake.addWatcherMutex.Unlock()
 	if fake.AddWatcherStub != nil {
-		fake.AddWatcherStub(arg1, arg2)
+		return fake.AddWatcherStub(arg1, arg2)
 	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addWatcherReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeWatcherManager) AddWatcherCallCount() int {
@@ -49,7 +61,7 @@ func (fake *FakeWatcherManager) AddWatcherCallCount() int {
 	return len(fake.addWatcherArgsForCall)
 }
 
-func (fake *FakeWatcherManager) AddWatcherCalls(stub func(cfclient.App, prometheus.Registerer)) {
+func (fake *FakeWatcherManager) AddWatcherCalls(stub func(cfclient.App, prometheus.Registerer) error) {
 	fake.addWatcherMutex.Lock()
 	defer fake.addWatcherMutex.Unlock()
 	fake.AddWatcherStub = stub
@@ -60,6 +72,29 @@ func (fake *FakeWatcherManager) AddWatcherArgsForCall(i int) (cfclient.App, prom
 	defer fake.addWatcherMutex.RUnlock()
 	argsForCall := fake.addWatcherArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeWatcherManager) AddWatcherReturns(result1 error) {
+	fake.addWatcherMutex.Lock()
+	defer fake.addWatcherMutex.Unlock()
+	fake.AddWatcherStub = nil
+	fake.addWatcherReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeWatcherManager) AddWatcherReturnsOnCall(i int, result1 error) {
+	fake.addWatcherMutex.Lock()
+	defer fake.addWatcherMutex.Unlock()
+	fake.AddWatcherStub = nil
+	if fake.addWatcherReturnsOnCall == nil {
+		fake.addWatcherReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addWatcherReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeWatcherManager) DeleteWatcher(arg1 string) {


### PR DESCRIPTION
https://trello.com/c/WrfWX3my/775-handle-errors-in-paas-prometheus-exporter



## Bubble up and log.Fatal all errors

Errors that could be thrown include
- doppler
- CF API
- Prometheus go client library

Previously we had return values from functions that could return
an error which would then be ignored. Now instead all errors
are captured and bubbled up. Final handling of those errors
is done using log.Fatal. We log fatally in both app_watcher.go
and exporter.go as both `appWatcher.Run` and `exporter.Start`
are run as go routines elsewhere.

## Remove unneeded default param for `InsecureSkipVerify`
Whilst I was solving the above problem, I spotted a leftover TODO
in our code which I took a few minutes to remove.
This is a leftover from the paas-metric-exporter where you
were able to turn off HTTPS. We have removed that behaviour
but still have an explicit setting of `InsecureSkipVerify` to
false. Infact we don't need to do this as it is default
behaviour as defined in:

https://github.com/cloudfoundry-community/go-cfclient/blob/0b4a58fd58d5b4c8fddde533ea9a9a114277bd4f/client.go#L67
