### PR TITLE
Fix closing behaviour

### DIFF
--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -176,10 +176,7 @@ func (m *AppWatcher) mainLoop(msgs <-chan *sonde_events.Envelope, errs <-chan er
 		select {
 		case message, ok := <-msgs:
 			if !ok {
-				// delete all instances
-				m.Close()
-				msgs = nil
-				continue
+				return fmt.Errorf("AppWatcher messages channel was closed, for guid %s", m.appGuid)
 			}
 			switch message.GetEventType() {
 			case sonde_events.Envelope_LogMessage:
@@ -194,8 +191,7 @@ func (m *AppWatcher) mainLoop(msgs <-chan *sonde_events.Envelope, errs <-chan er
 			}
 		case err, ok := <-errs:
 			if !ok {
-				errs = nil
-				continue
+				return fmt.Errorf("AppWatcher errors channel was closed, for guid %s", m.appGuid)
 			}
 			if err == nil {
 				continue

--- a/events/app_watcher.go
+++ b/events/app_watcher.go
@@ -1,11 +1,11 @@
 package events
 
 import (
-	"fmt"
 	"bytes"
 	"encoding/json"
-	"time"
+	"fmt"
 	"log"
+	"time"
 
 	sonde_events "github.com/cloudfoundry/sonde-go/events"
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,58 +41,58 @@ func NewInstanceMetrics(instanceIndex int, registerer prometheus.Registerer) (In
 		Registerer: registerer,
 		Cpu: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "cpu",
-				Help: "CPU utilisation in percent (0-100)",
+				Name:        "cpu",
+				Help:        "CPU utilisation in percent (0-100)",
 				ConstLabels: constLabels,
 			},
 		),
 		Crashes: prometheus.NewCounter(
 			prometheus.CounterOpts{
-				Name: "crashes",
-				Help: "Number of app instance crashes",
+				Name:        "crashes",
+				Help:        "Number of app instance crashes",
 				ConstLabels: constLabels,
 			},
 		),
 		DiskBytes: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "disk_bytes",
-				Help: "Disk usage in bytes",
+				Name:        "disk_bytes",
+				Help:        "Disk usage in bytes",
 				ConstLabels: constLabels,
 			},
 		),
 		DiskUtilization: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "disk_utilization",
-				Help: "Disk space currently in use in percent (0-100)",
+				Name:        "disk_utilization",
+				Help:        "Disk space currently in use in percent (0-100)",
 				ConstLabels: constLabels,
 			},
 		),
 		MemoryBytes: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "memory_bytes",
-				Help: "Memory usage in bytes",
+				Name:        "memory_bytes",
+				Help:        "Memory usage in bytes",
 				ConstLabels: constLabels,
 			},
 		),
 		MemoryUtilization: prometheus.NewGauge(
 			prometheus.GaugeOpts{
-				Name: "memory_utilization",
-				Help: "Memory currently in use in percent (0-100)",
+				Name:        "memory_utilization",
+				Help:        "Memory currently in use in percent (0-100)",
 				ConstLabels: constLabels,
 			},
 		),
 		Requests: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
-				Name: "requests",
-				Help: "Counter of http requests for a given app instance",
+				Name:        "requests",
+				Help:        "Counter of http requests for a given app instance",
 				ConstLabels: constLabels,
 			},
 			[]string{"status_range"},
 		),
 		ResponseTime: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name: "response_time",
-				Help: "Histogram of http request time for a given app instance",
+				Name:        "response_time",
+				Help:        "Histogram of http request time for a given app instance",
 				ConstLabels: constLabels,
 			},
 			[]string{"status_range"},
@@ -161,7 +161,7 @@ func NewAppWatcher(
 	return appWatcher, nil
 }
 
-func (m *AppWatcher) Run(){
+func (m *AppWatcher) Run() {
 	msgs, errs := m.streamProvider.OpenStreamFor(m.appGuid)
 	defer m.streamProvider.Close()
 
@@ -276,7 +276,7 @@ func (m *AppWatcher) processHttpStartStopMetric(httpStartStop *sonde_events.Http
 	responseDuration := time.Duration(httpStartStop.GetStopTimestamp() - httpStartStop.GetStartTimestamp()).Seconds()
 	index := int(httpStartStop.GetInstanceIndex())
 	if index < len(m.MetricsForInstance) {
-		statusRange := fmt.Sprintf("%dxx", *httpStartStop.StatusCode / 100)
+		statusRange := fmt.Sprintf("%dxx", *httpStartStop.StatusCode/100)
 		m.MetricsForInstance[index].Requests.WithLabelValues(statusRange).Inc()
 		m.MetricsForInstance[index].ResponseTime.WithLabelValues(statusRange).Observe(responseDuration)
 	}
@@ -303,7 +303,7 @@ func (m *AppWatcher) scaleTo(newInstanceCount int) error {
 		}
 	} else {
 		for i := currentInstanceCount; i > newInstanceCount; i-- {
-			m.MetricsForInstance[i - 1].unregisterInstanceMetrics()
+			m.MetricsForInstance[i-1].unregisterInstanceMetrics()
 		}
 		m.MetricsForInstance = m.MetricsForInstance[0:newInstanceCount]
 	}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	version            = "0.0.1"
+	version            = "0.0.2"
 	apiEndpoint        = kingpin.Flag("api-endpoint", "API endpoint").Default("https://api.10.244.0.34.xip.io").OverrideDefaultFromEnvar("API_ENDPOINT").String()
 	username           = kingpin.Flag("username", "UAA username.").Default("").OverrideDefaultFromEnvar("USERNAME").String()
 	password           = kingpin.Flag("password", "UAA password.").Default("").OverrideDefaultFromEnvar("PASSWORD").String()


### PR DESCRIPTION
If these channels are closed, it's because there is a non-recoverable
error in the doppler stream client.  At this point there's nothing
much we can do other than propagate the error back up and have it
crash the app with log.Fatal().

There were two problems with the previous behaviour:

1. possibility of double-closing a channel

Calling m.Close() when the messages channel is closed was a cute way
of getting us to scale down to 0 metrics.  However, it causes a
hazard, because the consumer (ie the Exporter) doesn't know that the
appInstancesChannel has been closed and so may well try to close it
again in future.  This would be a second close on an already-closed
channel, which causes a panic.

2. ignoring unrecoverable problems

When the noaa channels (ie, msgs and errs) are closed, this is a sign
that noaa has encountered a problem it can't deal with - eg, the
websocket connection has failed.  If we just call `continue` and go
round the loop again, we leave the AppWatcher in a state where it
won't get any more metrics, but the Exporter doesn't know that there
have been any problems.

The fix is simple: when the channels are closed, we exit the
AppWatcher mainLoop() with an error which will be logged out with
log.Fatal() in AppWatcher.Run(), crashing the whole app so that we can
do a clean restart.