### PR TITLE
Add http basic auth as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/mo
 |Update frequency|update-frequency|UPDATE_FREQUENCY|300|The time in seconds, that takes between each apps update call|
 |Scrape interval|scrape-interval|SCRAPE_INTERVAL|60|Scrape interval in seconds. Set this to the same value as the Prometheus scrape interval. The service metrics will be refreshed using the same interval|
 |Log-cache endpoint|logcache-endpoint|LOGCACHE_ENDPOINT|`https://log-cache.<PaaS system domain>`|Usually it's unnecessary to override this|
+|Basic-auth username|auth-username|AUTH_USERNAME|Apply basic auth protection to the /metrics endpoint|Leave this field blank to disable basic auth
+|Basic-auth password|auth-password|AUTH_PASSWORD||
 
 ## Development
 

--- a/util/basic_auth.go
+++ b/util/basic_auth.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+    "net/http"
+    "fmt"
+)
+
+func BasicAuthHandler(user, pass, realm string, next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        if checkBasicAuth(r, user, pass) {
+            next(w, r)
+            return
+        }
+
+        w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
+        w.WriteHeader(401)
+        w.Write([]byte("401 Unauthorized\n"))
+    }
+}
+
+func checkBasicAuth(r *http.Request, user, pass string) bool {
+    u, p, ok := r.BasicAuth()
+    if !ok {
+        return false
+    }
+    return u == user && p == pass
+}


### PR DESCRIPTION
Hi,

We'd like the ability to apply basic-auth to the /metrics endpoint, so forked and raised this PR. It saves having to manage an additional route service.

The basic-auth is optional and only enabled if the AUTH_USERNAME/AUTH_PASSWORD env vars are provided.

Cheers,
Lyndon (DIT webops)

