### PR TITLE
Add http basic auth as an option (with tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Refer to the [PaaS Technical Documentation](https://docs.cloud.service.gov.uk/mo
 |Update frequency|update-frequency|UPDATE_FREQUENCY|300|The time in seconds, that takes between each apps update call|
 |Scrape interval|scrape-interval|SCRAPE_INTERVAL|60|Scrape interval in seconds. Set this to the same value as the Prometheus scrape interval. The service metrics will be refreshed using the same interval|
 |Log-cache endpoint|logcache-endpoint|LOGCACHE_ENDPOINT|`https://log-cache.<PaaS system domain>`|Usually it's unnecessary to override this|
+|Basic-auth username|auth-username|AUTH_USERNAME|Apply basic auth protection to the /metrics endpoint|Leave this field blank to disable basic auth
+|Basic-auth password|auth-password|AUTH_PASSWORD||
 
 ## Development
 

--- a/main.go
+++ b/main.go
@@ -118,11 +118,11 @@ func main() {
 
 	promHandler := promhttp.Handler()
 
-	if *auth_username != "" {
-		http.Handle("/metrics", util.BasicAuthHandler(*authUsername, *authPassword, "metrics", promHandler))
-	} else {
-		http.Handle("/metrics", promHandler)
+	if *authUsername != "" {
+		promHandler = util.BasicAuthHandler(*authUsername, *authPassword, "metrics", promHandler)
 	}
+
+	http.Handle("/metrics", promHandler)
 
 	go func() {
 		err := server.ListenAndServe()

--- a/main.go
+++ b/main.go
@@ -118,8 +118,8 @@ func main() {
 
 	promHandler := promhttp.Handler()
 
-	if *authUsername != "" {
-		http.HandleFunc("/metrics", util.BasicAuthHandler(*authUsername, *authPassword, "metrics", promHandler.ServeHTTP))
+	if *auth_username != "" {
+		http.Handle("/metrics", util.BasicAuthHandler(*authUsername, *authPassword, "metrics", promHandler))
 	} else {
 		http.Handle("/metrics", promHandler)
 	}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/alphagov/paas-prometheus-exporter/app"
 	"github.com/alphagov/paas-prometheus-exporter/cf"
 	"github.com/alphagov/paas-prometheus-exporter/service"
+	"github.com/alphagov/paas-prometheus-exporter/util"
 
 	"github.com/cloudfoundry-community/go-cfclient"
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,6 +34,8 @@ var (
 	updateFrequency    = kingpin.Flag("update-frequency", "The time in seconds, that takes between each apps update call.").Default("300").OverrideDefaultFromEnvar("UPDATE_FREQUENCY").Int64()
 	scrapeInterval     = kingpin.Flag("scrape-interval", "The time in seconds, that takes between Prometheus scrapes.").Default("60").OverrideDefaultFromEnvar("SCRAPE_INTERVAL").Int64()
 	prometheusBindPort = kingpin.Flag("prometheus-bind-port", "The port to bind to for prometheus metrics.").Default("8080").OverrideDefaultFromEnvar("PORT").Int()
+	authUsername       = kingpin.Flag("auth-username", "HTTP basic auth username; leave blank to disable basic auth").Default("").OverrideDefaultFromEnvar("AUTH_USERNAME").String()
+	authPassword       = kingpin.Flag("auth-password", "HTTP basic auth password").Default("").OverrideDefaultFromEnvar("AUTH_PASSWORD").String()
 )
 
 type ServiceDiscovery interface {
@@ -112,7 +115,14 @@ func main() {
 	server := &http.Server{
 		Addr: fmt.Sprintf(":%d", *prometheusBindPort),
 	}
-	http.Handle("/metrics", promhttp.Handler())
+
+	promHandler := promhttp.Handler()
+
+	if *authUsername != "" {
+		http.HandleFunc("/metrics", util.BasicAuthHandler(*authUsername, *authPassword, "metrics", promHandler.ServeHTTP))
+	} else {
+		http.Handle("/metrics", promHandler)
+	}
 
 	go func() {
 		err := server.ListenAndServe()

--- a/main_suite_test.go
+++ b/main_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Building the HTTP server", func() {
+	var (
+		port        int
+		username    string
+		password    string
+		server      *http.Server
+		promHandler *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		port = 8080
+		username, password = "", ""
+
+		promHandler = ghttp.NewUnstartedServer()
+		promHandler.AllowUnhandledRequests = true
+		promHandler.UnhandledRequestStatusCode = http.StatusOK
+	})
+
+	JustBeforeEach(func() {
+		server = buildHTTPServer(port, promHandler, username, password)
+	})
+
+	It("constructs the server to listen on the given port", func() {
+		Expect(server.Addr).To(Equal(":8080"))
+	})
+
+	It("passes /metrics requests to the given handler", func() {
+		req := httptest.NewRequest("GET", "http://www.example.com/metrics", nil)
+		resp := httptest.NewRecorder()
+		server.Handler.ServeHTTP(resp, req)
+
+		Expect(resp.Code).To(Equal(http.StatusOK))
+		Expect(promHandler.ReceivedRequests()).To(HaveLen(1))
+	})
+
+	It("returns a 404 for other paths", func() {
+		req := httptest.NewRequest("GET", "http://www.example.com/", nil)
+		resp := httptest.NewRecorder()
+		server.Handler.ServeHTTP(resp, req)
+
+		Expect(resp.Code).To(Equal(http.StatusNotFound))
+		Expect(promHandler.ReceivedRequests()).To(HaveLen(0))
+	})
+
+	Context("with basic auth", func() {
+		BeforeEach(func() {
+			username = "user"
+			password = "secret"
+		})
+
+		It("rejects requests without basic auth", func() {
+			req := httptest.NewRequest("GET", "http://www.example.com/metrics", nil)
+			req.SetBasicAuth(username, "not-the-password")
+			resp := httptest.NewRecorder()
+			server.Handler.ServeHTTP(resp, req)
+
+			Expect(resp.Code).To(Equal(http.StatusUnauthorized))
+			Expect(promHandler.ReceivedRequests()).To(HaveLen(0))
+		})
+
+		It("allows valid requests through", func() {
+			req := httptest.NewRequest("GET", "http://www.example.com/metrics", nil)
+			req.SetBasicAuth(username, password)
+			resp := httptest.NewRecorder()
+			server.Handler.ServeHTTP(resp, req)
+
+			Expect(resp.Code).To(Equal(http.StatusOK))
+			Expect(promHandler.ReceivedRequests()).To(HaveLen(1))
+		})
+	})
+})

--- a/util/basic_auth.go
+++ b/util/basic_auth.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 )
 
-func BasicAuthHandler(user, pass, realm string, next http.HandlerFunc) http.HandlerFunc {
+func BasicAuthHandler(user, pass, realm string, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if checkBasicAuth(r, user, pass) {
-			next(w, r)
+			next.ServeHTTP(w, r)
 			return
 		}
 

--- a/util/basic_auth.go
+++ b/util/basic_auth.go
@@ -1,0 +1,27 @@
+package util
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func BasicAuthHandler(user, pass, realm string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if checkBasicAuth(r, user, pass) {
+			next(w, r)
+			return
+		}
+
+		w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Basic realm="%s"`, realm))
+		w.WriteHeader(401)
+		w.Write([]byte("401 Unauthorized\n"))
+	}
+}
+
+func checkBasicAuth(r *http.Request, user, pass string) bool {
+	u, p, ok := r.BasicAuth()
+	if !ok {
+		return false
+	}
+	return u == user && p == pass
+}

--- a/util/basic_auth_test.go
+++ b/util/basic_auth_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Basic auth handler", func() {
 		backend = ghttp.NewUnstartedServer()
 		backend.AllowUnhandledRequests = true
 		backend.UnhandledRequestStatusCode = http.StatusOK
-		authHandler = util.BasicAuthHandler(username, password, realm, backend.ServeHTTP)
+		authHandler = util.BasicAuthHandler(username, password, realm, backend)
 		req = httptest.NewRequest("GET", "http://www.example.com/", nil)
 		response = httptest.NewRecorder()
 	})

--- a/util/basic_auth_test.go
+++ b/util/basic_auth_test.go
@@ -1,0 +1,67 @@
+package util_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/alphagov/paas-prometheus-exporter/util"
+)
+
+var _ = Describe("Basic auth handler", func() {
+	const (
+		username = "user"
+		password = "secret"
+		realm    = "auth"
+	)
+
+	var (
+		backend     *ghttp.Server
+		authHandler http.Handler
+		req         *http.Request
+		response    *httptest.ResponseRecorder
+	)
+
+	BeforeEach(func() {
+		backend = ghttp.NewUnstartedServer()
+		backend.AllowUnhandledRequests = true
+		backend.UnhandledRequestStatusCode = http.StatusOK
+		authHandler = util.BasicAuthHandler(username, password, realm, backend.ServeHTTP)
+		req = httptest.NewRequest("GET", "http://www.example.com/", nil)
+		response = httptest.NewRecorder()
+	})
+
+	JustBeforeEach(func() {
+		authHandler.ServeHTTP(response, req)
+	})
+
+	Context("with the correct username and password", func() {
+		BeforeEach(func() {
+			req.SetBasicAuth(username, password)
+		})
+
+		It("should pass the request to the backend", func() {
+			Expect(response.Code).To(Equal(http.StatusOK))
+
+			Expect(backend.ReceivedRequests()).To(HaveLen(1))
+		})
+	})
+
+	Context("with invalid credentials", func() {
+		BeforeEach(func() {
+			req.SetBasicAuth(username, "not the password")
+		})
+
+		It("returns a 401 Unauthorized", func() {
+			Expect(response.Code).To(Equal(http.StatusUnauthorized))
+			Expect(response.Header().Get("WWW-Authenticate")).To(Equal(`Basic realm="auth"`))
+		})
+
+		It("does not make a request to the backend", func() {
+			Expect(backend.ReceivedRequests()).To(HaveLen(0))
+		})
+	})
+})


### PR DESCRIPTION
## What

This supersedes #16, to take that implementation and add tests around it.

I've also taken the opportunity to refactor it a little and to add some tests around the construction of the http server in the main package.

## How to review

* Code review
* Deploy the exporter and verify it works.
* Enable basic auth, and verify that works.

## Who can review

Not me.