### PR TITLE
[#1275640] Change HTTP client used for log-cache

### DIFF
--- a/cf/client.go
+++ b/cf/client.go
@@ -127,7 +127,7 @@ func (c *client) NewLogCacheClient() LogCacheClient {
 	return logcache.NewClient(c.logCacheEndpoint,
 		logcache.WithHTTPClient(&logCacheHTTPClient{
 			tokenSource: c.cfClient.Config.TokenSource,
-			client:      c.cfClient.Config.HttpClient,
+			client:      http.DefaultClient,
 		}),
 	)
 }


### PR DESCRIPTION
log-cache was using the same HTTP client as the app metrics client - this was causing the Authorization header we set to be overwritten with 'Bearer $token'.

Apparently log-cache no longer likes `Bearer` to be present in the header value.

Using `http.DefaultClient` rather than the one cfclient generates resolves this.


## Testing

Deploy from this branch, and ensure that service metrics are available when hitting the `/metrics` endpoint, and that no errors are seen in the logs

## Who can review?

Not @tnwhitwell or @jpluscplusm 