### PR TITLE
[#1275640] Change HTTP client and headers used for log-cache

### DIFF
--- a/cf/client.go
+++ b/cf/client.go
@@ -143,7 +143,8 @@ func (l *logCacheHTTPClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("failed to get token: %s", err)
 	}
 
-	req.Header.Set("Authorization", token.AccessToken)
+	authHeader := fmt.Sprintf("bearer %s", token.AccessToken)
+	req.Header.Set("Authorization", authHeader)
 
 	return l.client.Do(req)
 }


### PR DESCRIPTION
log-cache was using the same HTTP client as the app metrics client - this was causing the Authorization header we set to be overwritten with 'Bearer $token'.

Apparently log-cache no longer likes `Bearer` to be present in the header value, but instead wants 'bearer'.

Using `http.DefaultClient` rather than the one from cfclient, and adding `bearer ${TOKEN}` resolves this.

## Testing
Deploy from this branch, and ensure that service metrics are available when hitting the /metrics endpoint, and that no errors are seen in the logs

## Who can review?
Not @tnwhitwell or @jpluscplusm