### PR TITLE
Upgrade PaaS stack to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,5 +5,6 @@ applications:
   instances: 1
   buildpacks:
     - go_buildpack
+  stack: cflinuxfs3
   env:
     GOPACKAGENAME: github.com/alphagov/paas-prometheus-exporter


### PR DESCRIPTION
- This is the Ubuntu Bionic stack as cflinuxfs2 (Ubuntu Trusty) goes out
  of support soon.