### PR TITLE
[#168221165] Ignore HttpStartStop messages with PeerType = Server

### DIFF
--- a/app/watcher.go
+++ b/app/watcher.go
@@ -280,6 +280,10 @@ func (w *Watcher) processLogMessage(logMessage *sonde_events.LogMessage) error {
 }
 
 func (w *Watcher) processHttpStartStopMetric(httpStartStop *sonde_events.HttpStartStop) {
+	if httpStartStop.PeerType != nil && *httpStartStop.PeerType == sonde_events.PeerType_Server {
+		return
+	}
+
 	responseDuration := time.Duration(httpStartStop.GetStopTimestamp() - httpStartStop.GetStartTimestamp()).Seconds()
 	index := int(httpStartStop.GetInstanceIndex())
 	if index < len(w.MetricsForInstance) {


### PR DESCRIPTION
What
---
We always receive two HttpStartStop messages per requests. One has a peer type
of client, and the other has a peer type of server. The former includes an
instance index, indicating which application index the request was routed to.
The latter does not, but the library we use converts the nil to a zero.

This was causing every HttpStartStop message with PeerType = Server to be
interpreted as a request routed to app instance zero. This resulted in the
HTTP requests metrics being reported as N+1, where N is the number of requests
across all app instances.

How to review
---
1. Code review
2. Check the tests

Who can review
---
Anyone