### PR TITLE
[#178755576] Reduce API calls

### DIFF
--- a/cf/client.go
+++ b/cf/client.go
@@ -14,6 +14,10 @@ import (
 	"github.com/cloudfoundry/noaa/consumer"
 )
 
+var maxItemsPerPage = url.Values{
+	"results-per-page": []string{"100"},
+}
+
 type ServiceInstance struct {
 	cfclient.ServiceInstance
 	SpaceData cfclient.SpaceResource
@@ -51,7 +55,7 @@ func NewClient(config *cfclient.Config, logCacheEndpoint string) (Client, error)
 }
 
 func (c *client) getOrgsAndSpacesByGuid() (map[string]cfclient.Org, map[string]cfclient.Space, error) {
-	orgs, err := c.cfClient.ListOrgs()
+	orgs, err := c.cfClient.ListOrgsByQuery(maxItemsPerPage)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -59,7 +63,7 @@ func (c *client) getOrgsAndSpacesByGuid() (map[string]cfclient.Org, map[string]c
 	for _, org := range orgs {
 		orgsByGuid[org.Guid] = org
 	}
-	spaces, err := c.cfClient.ListSpaces()
+	spaces, err := c.cfClient.ListSpacesByQuery(maxItemsPerPage)
 	if err != nil {
 		return orgsByGuid, nil, err
 	}
@@ -76,7 +80,7 @@ func (c *client) ListAppsWithSpaceAndOrg() ([]cfclient.App, error) {
 		return nil, err
 	}
 
-	apps, err := c.cfClient.ListAppsByQuery(url.Values{})
+	apps, err := c.cfClient.ListAppsByQuery(maxItemsPerPage)
 	if err != nil {
 		return apps, err
 	}
@@ -111,7 +115,7 @@ func (c *client) ListServicesWithSpaceAndOrg() ([]ServiceInstance, error) {
 		return nil, err
 	}
 
-	services, err := c.cfClient.ListServiceInstances()
+	services, err := c.cfClient.ListServiceInstancesByQuery(maxItemsPerPage)
 	if err != nil {
 		return nil, err
 	}

--- a/cf/client_test.go
+++ b/cf/client_test.go
@@ -33,13 +33,13 @@ var _ = Describe("Client", func() {
 
 		httpmock.RegisterResponder(
 			"GET",
-			"http://api.bosh-lite.com/v2/organizations?",
+			"http://api.bosh-lite.com/v2/organizations?results-per-page=100",
 			httpmock.NewStringResponder(200, `{"resources":[{"metadata":{"guid":"some-org-guid"}}]}`),
 		)
 
 		httpmock.RegisterResponder(
 			"GET",
-			"http://api.bosh-lite.com/v2/spaces?",
+			"http://api.bosh-lite.com/v2/spaces?results-per-page=100",
 			httpmock.NewStringResponder(200, `{"resources":[{
 				"metadata":{"guid":"some-space-guid"},
 				"entity":{"organization_guid":"some-org-guid"}
@@ -48,7 +48,7 @@ var _ = Describe("Client", func() {
 
 		httpmock.RegisterResponder(
 			"GET",
-			"http://api.bosh-lite.com/v2/apps?",
+			"http://api.bosh-lite.com/v2/apps?results-per-page=100",
 			httpmock.NewStringResponder(200, `{"resources":[{"entity":{"space_guid":"some-space-guid","organization_guid":"some-org-guid"}}]}`),
 		)
 
@@ -70,13 +70,13 @@ var _ = Describe("Client", func() {
 
 		httpmock.RegisterResponder(
 			"GET",
-			"http://api.bosh-lite.com/v2/organizations?",
+			"http://api.bosh-lite.com/v2/organizations?results-per-page=100",
 			httpmock.NewStringResponder(200, `{"resources":[{"metadata":{"guid":"some-org-guid"}}]}`),
 		)
 
 		httpmock.RegisterResponder(
 			"GET",
-			"http://api.bosh-lite.com/v2/spaces?",
+			"http://api.bosh-lite.com/v2/spaces?results-per-page=100",
 			httpmock.NewStringResponder(200, `{"resources":[{
 				"metadata":{"guid":"some-space-guid"},
 				"entity":{"organization_guid":"some-org-guid"}
@@ -84,7 +84,7 @@ var _ = Describe("Client", func() {
 		)
 		httpmock.RegisterResponder(
 			"GET",
-			"http://api.bosh-lite.com/v2/service_instances?",
+			"http://api.bosh-lite.com/v2/service_instances?results-per-page=100",
 			httpmock.NewStringResponder(200, `{"resources":[{"entity": {"space_guid":"some-space-guid"}}]}`),
 		)
 


### PR DESCRIPTION
What
---

Tenants with lots of apps and services have been bumping up against our CF API rate limiting because the exporter makes so many API requests.

In attempt to reduce the number of calls being made, we are increasing the number of results returned per API call (where said API call supports it). The default page size is 50, and we're doubling it to 100. 

We don't expect this to fix the issue right away, but it should be a step in the right direction

How to test
---
Deploy to a place with lots of apps and services and see how it gets on

