### PR TITLE
185509385 - Pin GitHub Actions to specific hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: setup
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '^1.15'
+          go-version: '1.18'
 
       - name: checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
       - name: test
         run: make test


### PR DESCRIPTION
Description:
- Currently we pin to versions which means that we automatically pull in the latest changes which presents a security risk as we don't know which code is running in our build pipeline.
- This PR fixes this by pinning to a specific hash
- A future PR will configure dependabot to raise PR's automatically for later versions of GitHub Actions against their hashes