### PR TITLE
185509385 - Configure dependabot to track GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: github-action


### PR DESCRIPTION
Description:
- Dependabot will raise a PR for GitHub actions with a hash for the newer version
- Currently set to weekly to follow the current practice but this can be changed later pending an RFC